### PR TITLE
fix api leak

### DIFF
--- a/fiosdk/build.gradle
+++ b/fiosdk/build.gradle
@@ -11,14 +11,14 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
-    api 'com.squareup.retrofit2:retrofit:2.5.0'
-    api 'com.squareup.retrofit2:converter-gson:2.5.0'
-    api 'com.squareup.okhttp3:logging-interceptor:3.12.1'
+    implementation 'com.squareup.retrofit2:retrofit:2.5.0'
+    implementation 'com.squareup.retrofit2:converter-gson:2.5.0'
+    implementation 'com.squareup.okhttp3:logging-interceptor:3.12.1'
 
-    api 'org.bouncycastle:bcprov-jdk15on:1.61'
-    api 'org.bouncycastle:bcpkix-jdk15on:1.61'
-    api 'com.google.guava:guava:27.1-jre'
-    api 'org.bitcoinj:bitcoinj-core:0.15.2'
+    implementation 'org.bouncycastle:bcprov-jdk15on:1.61'
+    implementation 'org.bouncycastle:bcpkix-jdk15on:1.61'
+    implementation 'com.google.guava:guava:27.1-jre'
+    implementation 'org.bitcoinj:bitcoinj-core:0.15.2'
 
 }
 


### PR DESCRIPTION
fiosdk dependencies were exposed using `api` which causes problems for
projects that use fiosdk as dependency and use the same libraries.