### PR TITLE
change minSdkVersion to 19

### DIFF
--- a/androidfioserializationprovider/build.gradle
+++ b/androidfioserializationprovider/build.gradle
@@ -17,6 +17,7 @@ android {
         targetSdkVersion 28
         versionCode 1
         versionName "1.0.0"
+        multiDexEnabled true
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 

--- a/androidfioserializationprovider/build.gradle
+++ b/androidfioserializationprovider/build.gradle
@@ -13,7 +13,7 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion 19
         targetSdkVersion 28
         versionCode 1
         versionName "1.0.0"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,5 @@
 apply plugin: 'com.android.application'
-
 apply plugin: 'kotlin-android'
-
 apply plugin: 'kotlin-android-extensions'
 
 android {
@@ -13,10 +11,11 @@ android {
     compileSdkVersion 28
     defaultConfig {
         applicationId "fiofoundation.io.fiokotlinsdktestapp"
-        minSdkVersion 24
+        minSdkVersion 19
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"
+        multiDexEnabled true
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     buildTypes {
@@ -25,7 +24,6 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
-
 }
 
 dependencies {
@@ -39,6 +37,4 @@ dependencies {
 
     implementation project(":androidfioserializationprovider")
     implementation project(":fiosdk")
-
-
 }


### PR DESCRIPTION
API 19 still has 7% market share. Support should not be dropped without
need.