### PR TITLE
set cmake to version 3.10.2...3.10.2

### DIFF
--- a/androidfioserializationprovider/src/main/cpp/CMakeLists.txt
+++ b/androidfioserializationprovider/src/main/cpp/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 # Sets the minimum version of CMake required to build the native library.
 
-cmake_minimum_required(VERSION 3.4.1)
+cmake_minimum_required(VERSION 3.10.2...3.10.2)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
 


### PR DESCRIPTION
the cmake version was allowed to vary which is bad for reproducibility.
With this change it may only be 3.10.2.