### PR TITLE
BD-1920 integrate burn address into Kotlin SDK

### DIFF
--- a/app/src/androidTest/java/fiofoundation/io/fiokotlinsdktestapp/DevSdkTests.kt
+++ b/app/src/androidTest/java/fiofoundation/io/fiokotlinsdktestapp/DevSdkTests.kt
@@ -124,6 +124,10 @@ class DevSdkTests
         val newFioDomain = this.generateTestingFioDomain()
         val newFioAddress = this.generateTestingFioAddress(newFioDomain)
 
+        Thread.sleep(4000)
+        val newFioDomainBurn = this.generateTestingFioDomain()
+        val newFioAddressBurn = this.generateTestingFioAddress(newFioDomainBurn)
+
         val registerAddressFee = this.aliceFioSdk!!.getFee(FIOApiEndPoints.FeeEndPoint.RegisterFioAddress).fee
         val registerDomainFee = this.aliceFioSdk!!.getFee(FIOApiEndPoints.FeeEndPoint.RegisterFioDomain).fee
 
@@ -483,6 +487,93 @@ class DevSdkTests
         {
             throw AssertionError("Get Account Call Failed for Alice: " + generalException.message)
         }
+
+        println("testGenericActions: Test registerFioDomain")
+        Log.i(this.logTag,"testGenericActions: Test registerFioDomain")
+
+        try
+        {
+            val response = this.aliceFioSdk!!.registerFioDomain(newFioDomainBurn, registerDomainFee)
+
+            val actionTraceResponse = response.getActionTraceResponse()
+
+            Assert.assertTrue(
+                    "Couldn't register $newFioDomainBurn for Alice",
+                    actionTraceResponse != null && actionTraceResponse.status == "OK"
+            )
+
+            Log.i(this.logTag, "Registered Fio Domain: ${actionTraceResponse != null && actionTraceResponse.status == "OK"}")
+        }
+        catch (e: FIOError)
+        {
+            throw AssertionError("Register Fio Domain for Alice Failed: " + e.toJson())
+        }
+        catch (generalException: Exception)
+        {
+            throw AssertionError("Register Fio Domain for Alice Failed: " + generalException.message)
+        }
+
+
+        println("testGenericActions: Test registerFioAddress")
+        Log.i(this.logTag,"testGenericActions: Test registerFioAddress")
+
+        try
+        {
+            val response = this.aliceFioSdk!!.registerFioAddress(newFioAddressBurn,registerAddressFee)
+
+            val actionTraceResponse = response.getActionTraceResponse()
+
+            Assert.assertTrue(
+                    "Couldn't Register FioAddress $newFioAddressBurn for Alice",
+                    actionTraceResponse != null && actionTraceResponse.status == "OK"
+            )
+
+            Log.i(this.logTag, "Registered FioAddress: ${actionTraceResponse != null && actionTraceResponse.status == "OK"}")
+
+        }
+        catch (broadcastError: TransactionBroadCastError)
+        {
+            throw AssertionError("Alice's Funds Request Failed: " + broadcastError.toJson())
+        }
+        catch (e: FIOError)
+        {
+            throw AssertionError("Register FioAddress for Alice Failed: " + e.toJson())
+        }
+        catch (generalException: Exception)
+        {
+            throw AssertionError("Register FioAddress for Alice Failed: " + generalException.message)
+        }
+
+
+
+
+        println("testGenericActions: Test burnFIOAddress")
+        Log.i(this.logTag,"testGenericActions: Test burnFIOAddress")
+
+        try
+        {
+            val burnAddressFee = this.aliceFioSdk!!.getFeeForBurnFIOAddress(newFioAddressBurn).fee
+
+            val response = this.aliceFioSdk!!.burnFIOAddress(newFioAddressBurn,burnAddressFee,"")
+
+            val actionTraceResponse = response.getActionTraceResponse()
+
+            Assert.assertTrue(
+                    "Couldn't Burn Address for Alice",
+                    actionTraceResponse != null && actionTraceResponse.status == "OK"
+            )
+
+            Log.i(this.logTag, "Burned FIO address: ${actionTraceResponse != null && actionTraceResponse.status == "OK"}")
+        }
+        catch (e: FIOError)
+        {
+            throw AssertionError("Burn FIO Address  for Alice Failed: " + e.toJson())
+        }
+        catch (generalException: Exception)
+        {
+            throw AssertionError("Burn FIO Address for Alice Failed: " + generalException.message)
+        }
+
 
 /*
 

--- a/fiosdk/src/main/java/fiofoundation/io/fiosdk/implementations/FIONetworkProvider.kt
+++ b/fiosdk/src/main/java/fiofoundation/io/fiosdk/implementations/FIONetworkProvider.kt
@@ -289,6 +289,19 @@ class FIONetworkProvider(private val baseURL: String): IFIONetworkProvider
         }
     }
 
+    @Throws(PushTransactionError::class)
+    override fun burnFIOAddress(pushTransactionRequest: PushTransactionRequest): PushTransactionResponse
+    {
+        try
+        {
+            val syncCall = this.networkProviderApi.burnFIOAddress(pushTransactionRequest)
+            return processCall(syncCall)
+        }
+        catch(e: FIONetworkProviderCallError){
+            throw PushTransactionError("",e,e.responseError)
+        }
+    }
+
     @Throws(GetLocksError::class)
     override fun getLocks(getLocksRequest: GetLocksRequest): GetLocksResponse{
         try

--- a/fiosdk/src/main/java/fiofoundation/io/fiosdk/interfaces/IFIONetworkProvider.kt
+++ b/fiosdk/src/main/java/fiofoundation/io/fiosdk/interfaces/IFIONetworkProvider.kt
@@ -14,6 +14,7 @@ interface IFIONetworkProvider {
     fun getFIOBalance(getFioBalanceRequest: GetFIOBalanceRequest): GetFIOBalanceResponse
     fun getLocks(getLocksRequest: GetLocksRequest): GetLocksResponse
     fun transferLockedTokensToPublicKey(pushTransactionRequest: PushTransactionRequest): PushTransactionResponse
+    fun burnFIOAddress(pushTransactionRequest: PushTransactionRequest): PushTransactionResponse
     fun getFee(getFeeRequest: GetFeeRequest): GetFeeResponse
     fun getInfo(): GetInfoResponse
     fun getBlock(getBlockRequest: GetBlockRequest): GetBlockResponse

--- a/fiosdk/src/main/java/fiofoundation/io/fiosdk/interfaces/IFIONetworkProviderApi.kt
+++ b/fiosdk/src/main/java/fiofoundation/io/fiosdk/interfaces/IFIONetworkProviderApi.kt
@@ -31,6 +31,9 @@ interface IFIONetworkProviderApi {
     @POST(FIOApiEndPoints.transfer_locked_tokens)
     fun transferLockedTokensToPublicKey(@Body pushTransactionRequest: PushTransactionRequest): Call<PushTransactionResponse>
 
+    @POST(FIOApiEndPoints.burn_fio_address)
+    fun burnFIOAddress(@Body pushTransactionRequest: PushTransactionRequest): Call<PushTransactionResponse>
+
     @POST(FIOApiEndPoints.get_fee)
     fun getFee(@Body getFeeRequest: GetFeeRequest): Call<GetFeeResponse>
 

--- a/fiosdk/src/main/java/fiofoundation/io/fiosdk/models/fionetworkprovider/FIOApiEndPoints.kt
+++ b/fiosdk/src/main/java/fiofoundation/io/fiosdk/models/fionetworkprovider/FIOApiEndPoints.kt
@@ -15,6 +15,7 @@ object FIOApiEndPoints {
     const val register_fio_address = "register_fio_address"
     const val transfer_tokens_pub_key = "transfer_tokens_pub_key"
     const val renew_fio_domain = "renew_fio_domain"
+    const val burn_fio_address = "burn_fio_address"
     const val renew_fio_address = "renew_fio_address"
     const val push_transaction = "push_transaction"
     const val get_required_keys = "get_required_keys"

--- a/fiosdk/src/main/java/fiofoundation/io/fiosdk/models/fionetworkprovider/actions/BurnFIOAddressAction.kt
+++ b/fiosdk/src/main/java/fiofoundation/io/fiosdk/models/fionetworkprovider/actions/BurnFIOAddressAction.kt
@@ -1,0 +1,39 @@
+package fiofoundation.io.fiosdk.models.fionetworkprovider.actions
+
+
+import com.google.gson.annotations.SerializedName
+import fiofoundation.io.fiosdk.models.fionetworkprovider.Authorization
+import fiofoundation.io.fiosdk.models.fionetworkprovider.request.FIORequestData
+import java.math.BigInteger
+
+class BurnFIOAddressAction(fioAddress: String,
+                           maxFee: BigInteger,
+                           technologyPartnerId: String,
+                           actorPublicKey: String) : IAction
+{
+    override var account = "fio.address"
+    override var name = "burnaddress"
+    override var authorization = ArrayList<Authorization>()
+    override var data = ""
+
+    init
+    {
+        val auth = Authorization(actorPublicKey, "active")
+        var requestData =
+            BurnFIOAddressRequestData(
+                fioAddress,
+                maxFee,
+                auth.actor,
+                technologyPartnerId
+            )
+
+        this.authorization.add(auth)
+        this.data = requestData.toJson()
+    }
+
+    class BurnFIOAddressRequestData(
+        @field:SerializedName("fio_address") var fio_address:String,
+        @field:SerializedName("max_fee") var max_fee:BigInteger,
+        @field:SerializedName("actor") var actor:String,
+        @field:SerializedName("tpid") var technologyPartnerId:String): FIORequestData()
+}

--- a/fiosdk/src/main/java/fiofoundation/io/fiosdk/session/processors/BurnFIOAddressTrxProcessor.kt
+++ b/fiosdk/src/main/java/fiofoundation/io/fiosdk/session/processors/BurnFIOAddressTrxProcessor.kt
@@ -1,0 +1,33 @@
+package fiofoundation.io.fiosdk.session.processors
+
+
+import fiofoundation.io.fiosdk.errors.ErrorConstants
+import fiofoundation.io.fiosdk.errors.fionetworkprovider.PushTransactionError
+import fiofoundation.io.fiosdk.errors.session.TransactionPushTransactionError
+import fiofoundation.io.fiosdk.interfaces.IABIProvider
+import fiofoundation.io.fiosdk.interfaces.IFIONetworkProvider
+import fiofoundation.io.fiosdk.interfaces.ISerializationProvider
+import fiofoundation.io.fiosdk.interfaces.ISignatureProvider
+import fiofoundation.io.fiosdk.models.fionetworkprovider.request.PushTransactionRequest
+import fiofoundation.io.fiosdk.models.fionetworkprovider.response.PushTransactionResponse
+
+class BurnFIOAddressTrxProcessor(serializationProvider: ISerializationProvider,
+                                 fioNetworkProvider: IFIONetworkProvider,
+                                 abiProvider: IABIProvider,
+                                 signatureProvider: ISignatureProvider
+) : TransactionProcessor(serializationProvider,fioNetworkProvider,abiProvider,signatureProvider)
+{
+    @Throws(TransactionPushTransactionError::class)
+    override fun pushTransaction(pushTransactionRequest: PushTransactionRequest): PushTransactionResponse {
+        try
+        {
+            return fioNetworkProvider.burnFIOAddress(pushTransactionRequest)
+        }
+        catch (pushTransactionError: PushTransactionError)
+        {
+            throw TransactionPushTransactionError(
+                ErrorConstants.TRANSACTION_PROCESSOR_RPC_PUSH_TRANSACTION,
+                pushTransactionError)
+        }
+    }
+}


### PR DESCRIPTION
this PR integrates the fio address contract burn address action into the FIO Kotlin SDK.
tests will be added to provide minimal regression of the new call.